### PR TITLE
Make sure a valid header checksum is present in all banks for some emulator multicart heuristics

### DIFF
--- a/emulator-only/mbc1/multicart_rom_8Mb.s
+++ b/emulator-only/mbc1/multicart_rom_8Mb.s
@@ -83,6 +83,7 @@ expected_banks:
 ; (e.g. mooneye-gb)
 
 .repeat CART_ROM_BANKS INDEX bank
+.ifgr bank 0
 .bank bank
 .org $0104
 .db $CE $ED $66 $66 $CC $0D $00 $0B $03 $73 $00 $83 $00 $0C $00 $0D
@@ -94,4 +95,5 @@ expected_banks:
 
 .db $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00
 .db $00 $00 $00 $00 $00 $00 $00 $00 $00 $E7 $00 $00 $00 $00 $00 $00
+.endif
 .endr

--- a/emulator-only/mbc1/multicart_rom_8Mb.s
+++ b/emulator-only/mbc1/multicart_rom_8Mb.s
@@ -88,4 +88,10 @@ expected_banks:
 .db $CE $ED $66 $66 $CC $0D $00 $0B $03 $73 $00 $83 $00 $0C $00 $0D
 .db $00 $08 $11 $1F $88 $89 $00 $0E $DC $CC $6E $E6 $DD $DD $D9 $99
 .db $BB $BB $67 $63 $6E $0E $EC $CC $DD $DC $99 $9F $BB $B9 $33 $3E
+
+; Also make sure the presumed header checksum is valid, as some emulators may
+; check that too
+
+.db $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00 $00
+.db $00 $00 $00 $00 $00 $00 $00 $00 $00 $E7 $00 $00 $00 $00 $00 $00
 .endr


### PR DESCRIPTION
Some emulators may check the header checksum along with the Nintendo logo, as both need to be valid for a presumed single game to actually boot