### PR TITLE
fix: description of intr_2_0_timing.s test

### DIFF
--- a/acceptance/ppu/intr_2_0_timing.s
+++ b/acceptance/ppu/intr_2_0_timing.s
@@ -18,7 +18,7 @@
 ; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ; SOFTWARE.
 
-; Tests how long does it take to get from STAT mode=1 interrupt to STAT mode=2 interrupt
+; Tests how long does it take to get from STAT mode=2 interrupt to STAT mode=0 interrupt
 ; No sprites, scroll or window.
 
 ; Verified results:


### PR DESCRIPTION
This PR fixes the description of the `intr_2_0_timing` test, as the description previously appeared to have the incorrect modes listed.